### PR TITLE
Experiment: inject context at runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ func main() {
 		return string(buf.Bytes()), nil
 	})
 
-	obs, err := exp.Run()
+	obs, err := exp.Run(nil)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -103,7 +103,6 @@ default values.
 - Comparison (nil)
 - Percentage (10)
 - Enabled (true)
-- Context (context.Background())
 - Before (nil)
 - Publisher (nil)
 - Testing (false)
@@ -126,7 +125,7 @@ func main() {
 
 	// add control/tests
 
-	exp.Run()
+	exp.Run(nil)
 
 	result := exp.Result()
 	fmt.Println(result.Mismatches)
@@ -203,37 +202,6 @@ func shouldRunExperiment(user User) bool {
 
 In this case, if the user is not confirmed yet, we will not run the experiment.
 
-### Context
-
-When using a context for your request, you might have information that you need
-within your test. Using the `Context()` option, you can now set a context that
-will be used to pass along to your test functions.
-
-```go
-func main() {
-	ctx := context.WithValue(context.Background(), "key", "value")
-
-	exp := experiment.New(
-		"context-example",
-		experiment.Context(ctx),
-	)
-	exp.Control(myControlFunc)
-
-	// do more experiment setup and run it
-}
-
-func myControlFunc(ctx context.Context) (interface{}, error) {
-	key := ctx.Value("key")
-
-	return key, nil
-}
-```
-
-In the above example, we create a new context and pass it along to the new
-experiment. The experiment runner is aware of this and passes that to any
-function that takes a `context.Context` type (our test and control cases). This
-makes it then available for these functions to use.
-
 ### Before
 
 When an expensive setup is required to do the test, we don't always want to run
@@ -303,6 +271,36 @@ func main() {
 Here we register two publishers. The statsd publisher will most likely publish
 the durations of the result, making them available for graphs. The Redis
 publisher can be used to store the mismatches that need investigating later on.
+
+## Context
+
+When using a context for your request, you might have information that you need
+within your test. By passing in a context to the `Run()` method, you can pass
+through this information.
+
+```go
+func main() {
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	exp := experiment.New(
+		"context-example",
+	)
+	exp.Control(myControlFunc)
+
+    exp.Run(ctx)
+}
+
+func myControlFunc(ctx context.Context) (interface{}, error) {
+	key := ctx.Value("key")
+
+	return key, nil
+}
+```
+
+In the above example, we create a new context and pass it along to our runner.
+The experiment runner is aware of this and passes that to any function that
+takes a `context.Context` type (our test and control cases). This makes it then
+available for these functions to use.
 
 ## Testing
 

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -59,7 +59,7 @@ func TestExperiment_Run_NoControl(t *testing.T) {
 	exp := New("control-test")
 	exp.Test("test-1", dummyTestFunc)
 
-	_, err := exp.Run()
+	_, err := exp.Run(context.Background())
 	assert.IsType(t, err, ErrMissingControl)
 }
 
@@ -67,7 +67,7 @@ func TestExperiment_Run_NoTest(t *testing.T) {
 	exp := New("control-test")
 	exp.Control(dummyControlFunc)
 
-	_, err := exp.Run()
+	_, err := exp.Run(context.Background())
 	assert.IsType(t, err, ErrMissingTest)
 }
 
@@ -77,7 +77,7 @@ func TestExperiment_Run(t *testing.T) {
 	exp.Control(dummyControlFunc)
 	exp.Test("test-1", dummyTestFunc)
 
-	obs, err := exp.Run()
+	obs, err := exp.Run(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, obs.Value().(string), "control")
@@ -89,7 +89,7 @@ func TestExperiment_Run_WithTestPanic(t *testing.T) {
 	exp.Control(dummyControlFunc)
 	exp.Test("panic-test", dummyTestPanicFunc)
 
-	obs, err := exp.Run()
+	obs, err := exp.Run(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, obs.Value().(string), "control")
@@ -103,14 +103,26 @@ func TestExperiment_Run_WithContext(t *testing.T) {
 	val := "my-context-test"
 	ctx := context.WithValue(context.Background(), "ctx-test", val)
 
-	exp := New("context-test", Context(ctx))
+	exp := New("context-test")
 	exp.Control(dummyContextTestFunc)
 	exp.Test("context-test", dummyTestFunc)
 
-	obs, err := exp.Run()
+	obs, err := exp.Run(ctx)
 
 	assert.Nil(t, err)
 	assert.Equal(t, obs.Value().(string), val)
+}
+
+func TestExperiment_Run_Without_Context(t *testing.T) {
+	exp := New("control-test")
+
+	exp.Control(dummyControlFunc)
+	exp.Test("test-1", dummyTestFunc)
+
+	obs, err := exp.Run(nil)
+
+	assert.Nil(t, err)
+	assert.Equal(t, obs.Value().(string), "control")
 }
 
 func TestExperiment_Run_Before(t *testing.T) {
@@ -127,7 +139,7 @@ func TestExperiment_Run_Before(t *testing.T) {
 	exp := New("before-test", Before(beforeFunc))
 	exp.Control(checkFunc)
 	exp.Test("before-test", checkFunc)
-	exp.Run()
+	exp.Run(context.Background())
 }
 
 func dummyContextTestFunc(ctx context.Context) (interface{}, error) {

--- a/options.go
+++ b/options.go
@@ -9,7 +9,6 @@ type (
 		testMode   bool
 		percentage float64
 		comparison ComparisonMethod
-		ctx        context.Context
 		before     []ContextMethod
 		publishers []ResultPublisher
 	}
@@ -31,7 +30,6 @@ func newOptions(ops ...Option) options {
 	opts := options{
 		enabled:    true,
 		percentage: 10,
-		ctx:        context.Background(),
 		before:     []ContextMethod{},
 		publishers: []ResultPublisher{},
 	}
@@ -86,14 +84,6 @@ func Compare(m ComparisonMethod) Option {
 func TestMode() Option {
 	return func(opts *options) {
 		opts.testMode = true
-	}
-}
-
-// Context is an option that allows you to add a context to the experiment. This
-// will be used as a base for injecting the context into your test methods.
-func Context(ctx context.Context) Option {
-	return func(opts *options) {
-		opts.ctx = ctx
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -16,7 +16,6 @@ func TestDefaultOptions(t *testing.T) {
 	assert.True(t, defaults.enabled, "Default enabler")
 	assert.False(t, defaults.testMode, "Default testMode")
 	assert.Nil(t, defaults.comparison, "Default comparison method")
-	assert.NotNil(t, defaults.ctx, "Default context")
 	assert.Len(t, defaults.before, 0)
 	assert.Len(t, defaults.publishers, 0)
 }
@@ -47,15 +46,6 @@ func TestOptions_Compare(t *testing.T) {
 	}
 	ops := newOptions(Compare(cmp))
 	assert.NotNil(t, ops.comparison, "Overwriting comparison method")
-}
-
-func TestOptions_Context(t *testing.T) {
-	val := "foo"
-	ctx := context.WithValue(context.Background(), "test-ctx", val)
-
-	ops := newOptions(Context(ctx))
-	ctxVal := ops.ctx.Value("test-ctx")
-	assert.Equal(t, val, ctxVal)
 }
 
 func TestOptions_Before(t *testing.T) {

--- a/result_test.go
+++ b/result_test.go
@@ -36,7 +36,7 @@ func runExperiment(exp *experiment.Experiment) {
 	exp.Control(dummyControlFunc)
 	exp.Test("test1", dummyTestFunc)
 	exp.Test("test2", dummyCompareTestFunc)
-	exp.Run()
+	exp.Run(context.Background())
 }
 
 func dummyTestFunc(ctx context.Context) (interface{}, error) {


### PR DESCRIPTION
By injecting the context when we create the experiment, it meant that
the experiment was always in a "fresh" state. This means that the
counter would always have been reset for the percentage option.

We now inject the context - and this also adds the posibility to add
`nil` - at runtime, which makes it possible to setup the experiment
outside of the concurrency scope but still use it concurrently.