### PR TITLE
Publisher: increment publish counter.

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -35,6 +35,7 @@ func (p *publisher) Publish(res Result) {
 		p.publishObservation(ob)
 	}
 
+	p.cl.Increment("publish.incr")
 	p.cl.Count("candidates.count", len(res.Candidates()))
 	p.cl.Count("mismatches.count", len(res.Mismatches()))
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -30,7 +30,7 @@ func TestPublisher_Publish_ErroredControl(t *testing.T) {
 	}
 
 	pub.Publish(experiment.NewResult(obs, nil))
-	require.Equal(t, 1, p.increments)
+	require.Equal(t, 2, p.increments)
 	require.Equal(t, 2, p.counts)
 	require.Equal(t, 1, p.timers)
 }
@@ -57,7 +57,7 @@ func TestPublisher_Publish_ErroredTests(t *testing.T) {
 	}
 
 	pub.Publish(experiment.NewResult(obs, nil))
-	require.Equal(t, 2, p.increments)
+	require.Equal(t, 3, p.increments)
 	require.Equal(t, 2, p.counts)
 	require.Equal(t, 2, p.timers)
 }


### PR DESCRIPTION
To calculate percentages of error rates properly, one needs a baseline of number of tests that have happened.

This adds a counter for the amount times a test has actually run.