### PR TITLE
Interfaces: remove internal interface dependencies.

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -65,12 +65,12 @@ func (e *Experiment) Test(name string, b BehaviourFunc) error {
 // that any actual experiment runs (from other runners) that happen between
 // requesting a new runner and actually running the test will not influence it's
 // state.
-func (e *Experiment) Runner() (Runner, error) {
+func (e *Experiment) Runner() (*Runner, error) {
 	if _, ok := e.behaviours[controlKey]; !ok {
 		return nil, ErrMissingControl
 	}
 
-	return &experimentRunner{
+	return &Runner{
 		experiment: e,
 		config:     e.Config,
 		behaviours: e.behaviours,

--- a/publisher.go
+++ b/publisher.go
@@ -28,7 +28,7 @@ func NewPublisher(client PublisherClient) *Publisher {
 // This will publish the number of candidates, mismatches and a hit counter.
 // Per observation - including the control - it will also publish the error
 // count, panic count and observation duration.
-func (p *Publisher) Publish(res Result) {
+func (p *Publisher) Publish(res *Result) {
 	p.publishObservation(res.Control())
 	for _, ob := range res.Candidates() {
 		p.publishObservation(ob)

--- a/result.go
+++ b/result.go
@@ -3,18 +3,7 @@ package experiment
 type (
 	// Result represents the result from running all the observations and comparing
 	// them with the given compare method.
-	Result interface {
-		// Mismatches represent the observations on which the given `Compare`
-		// option returned false.
-		Mismatches() []Observation
-		// Candidates represents all the observations which are not the control.
-		Candidates() []Observation
-		// Control represents the observation of the results from the control
-		// function.
-		Control() Observation
-	}
-
-	experimentResult struct {
+	Result struct {
 		mismatches   []Observation
 		candidates   []Observation
 		observations Observations
@@ -25,8 +14,8 @@ type (
 
 // NewResult takes an Observations type and will compare every test observation
 // in it with the control observation through the given ComparisonMethod.
-func NewResult(obs Observations, cm ComparisonMethod) Result {
-	return &experimentResult{
+func NewResult(obs Observations, cm ComparisonMethod) *Result {
+	return &Result{
 		observations: obs,
 		cm:           cm,
 	}
@@ -36,7 +25,7 @@ func NewResult(obs Observations, cm ComparisonMethod) Result {
 // to true with the given ComparisonMethod.
 // Note that this could potentially be an expensive method to run. It is advised
 // to look at these results in a goroutine.
-func (r *experimentResult) Mismatches() []Observation {
+func (r *Result) Mismatches() []Observation {
 	r.ensureRun()
 
 	return r.mismatches
@@ -46,18 +35,18 @@ func (r *experimentResult) Mismatches() []Observation {
 // with the given ComparisonMethod.
 // Note that this could potentially be an expensive method to run. It is advised
 // to look at these results in a goroutine.
-func (r *experimentResult) Candidates() []Observation {
+func (r *Result) Candidates() []Observation {
 	r.ensureRun()
 
 	return r.candidates
 }
 
 // Control returns the observation for the control test.
-func (r *experimentResult) Control() Observation {
+func (r *Result) Control() Observation {
 	return r.observations.Control()
 }
 
-func (r *experimentResult) ensureRun() {
+func (r *Result) ensureRun() {
 	if r.hasRun {
 		return
 	}

--- a/runner.go
+++ b/runner.go
@@ -9,19 +9,7 @@ import (
 // Runner represents the implementation that actually runs the tests. Runners
 // are not safe for concurrent use. Each concurrent request should request
 // a new runner from the experiment.
-type Runner interface {
-	// Run will run the tests with a given context.
-	Run(context.Context) Observations
-	// Disable forces the runner to not run the tests. This overrules the
-	// `Force()` method.
-	Disable(bool)
-	// Force forces the runner to run the tests no matter what the hitrate is or
-	// what other options are given.
-	Force(bool)
-	HasRun() bool
-}
-
-type experimentRunner struct {
+type Runner struct {
 	experiment *Experiment
 	behaviours map[string]*behaviour
 
@@ -36,19 +24,25 @@ type experimentRunner struct {
 	runs float32
 }
 
-func (r *experimentRunner) Disable(d bool) {
+// Disable forces the runner to not run the tests. This overrules the `Force()`
+// method.
+func (r *Runner) Disable(d bool) {
 	r.disabled = d
 }
 
-func (r *experimentRunner) Force(f bool) {
+// Force forces the runner to run the tests no matter what the hitrate is or
+// what other options are given.
+func (r *Runner) Force(f bool) {
 	r.force = f
 }
 
-func (r *experimentRunner) HasRun() bool {
+// HasRun returns wether or not the test has actually been executed.
+func (r *Runner) HasRun() bool {
 	return r.hasRun
 }
 
-func (r *experimentRunner) Run(ctx context.Context) Observations {
+// Run will run the tests with a given context.
+func (r *Runner) Run(ctx context.Context) Observations {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -96,7 +90,7 @@ func (r *experimentRunner) Run(ctx context.Context) Observations {
 	return obs
 }
 
-func (r *experimentRunner) shouldRun() bool {
+func (r *Runner) shouldRun() bool {
 	if r.testMode {
 		return true
 	}
@@ -112,7 +106,7 @@ func (r *experimentRunner) shouldRun() bool {
 	return false
 }
 
-func (r *experimentRunner) observe(ctx context.Context, beh *behaviour, obsch chan *Observation, tm bool) {
+func (r *Runner) observe(ctx context.Context, beh *behaviour, obsch chan *Observation, tm bool) {
 	obs := &Observation{Name: beh.name}
 
 	defer func() {


### PR DESCRIPTION
This removes the interface dependencies and return arguments. If an interface is needed externally, this can be easily implemented due to the exported types.