### PR TITLE
Context: remove external dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ func main() {
 		return
 	}
 
-    obs := runner.Run(nil)
+    obs := runner.Run(context.TODO())
 	str = obs.Control().Value.(string)
 	fmt.Println(str)
 }
@@ -78,6 +78,16 @@ control and tests(if applicable) in a random fashion. This means that one time
 the control could be run first, another time the test case could be run first.
 This is done so to avoid any accidental behavioural changes in any of the
 control or test code.
+
+## Context
+
+[Context](https://godoc.org/context) has been added to Go in version 1.7. For backwards compatibility,
+the Context interface has been copied to this library instead of relying on the
+Go 1.7 internal interface or the older `/x/net/context` interface.
+
+Note: when using a Context, one should always use an actual implementation of a
+context and not use `nil`. If the implementation isn't decided yet, use
+`context.TODO()`.
 
 ## Limitations and caveats
 
@@ -200,7 +210,7 @@ func main() {
 
 	// add control/tests
 
-	obs, err := exp.Run(nil)
+	obs, err := exp.Run(context.TODO())
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -262,7 +272,7 @@ Tests results can be obtained by creating a new Results handler.
 ```go
 func main () {
     // set up experiment and runner
-    obs := runner.Run(nil)
+    obs := runner.Run(context.TODO())
 
     res := experiment.NewResult(obs, comparisonMethod)
 

--- a/behaviour.go
+++ b/behaviour.go
@@ -1,7 +1,5 @@
 package experiment
 
-import "golang.org/x/net/context"
-
 type (
 	behaviour struct {
 		name string
@@ -13,7 +11,7 @@ type (
 	// key/value pairs and we expect it to return an interface and error. When
 	// the function is linked to a control behaviour, the returned interface and
 	// error will be used to be returned when the experiment is run.
-	BehaviourFunc func(context.Context) (interface{}, error)
+	BehaviourFunc func(Context) (interface{}, error)
 )
 
 func newBehaviour(name string, fnc BehaviourFunc) *behaviour {

--- a/config.go
+++ b/config.go
@@ -1,7 +1,5 @@
 package experiment
 
-import "golang.org/x/net/context"
-
 var (
 	// TestMode indicates if the code is executed as part of the test suite.
 	// When TestMode is enabled, all the experiment tests will always run,
@@ -20,7 +18,7 @@ type (
 
 	// BeforeFilter is a wrapper around a method that is purely used to take a
 	// context, adjust it and return a new context with the adjusted values.
-	BeforeFilter func(context.Context) context.Context
+	BeforeFilter func(Context) Context
 
 	// ComparisonMethod is used as an interface for creating a method in which we
 	// want to compare the observations of a test. This being the Control and a
@@ -29,7 +27,7 @@ type (
 
 	// ConditionalFunc is used to determine on run time whether or not we should
 	// run the tests.
-	ConditionalFunc func(context.Context) bool
+	ConditionalFunc func(Context) bool
 )
 
 // DefaultConfig sets up a default configuration where the Percentage is 100.

--- a/context.go
+++ b/context.go
@@ -1,0 +1,99 @@
+package experiment
+
+import "time"
+
+// Context carries a deadline, a cancelation signal, and other values across API boundaries.
+// Context's methods may be called by multiple goroutines simultaneously.
+//
+// This is a copy of the Go 1.7 implementation. For more information, see
+// https://godoc.org/context
+type Context interface {
+	// Deadline returns the time when work done on behalf of this context
+	// should be canceled. Deadline returns ok==false when no deadline is
+	// set. Successive calls to Deadline return the same results.
+	Deadline() (deadline time.Time, ok bool)
+
+	// Done returns a channel that's closed when work done on behalf of this
+	// context should be canceled. Done may return nil if this context can
+	// never be canceled. Successive calls to Done return the same value.
+	//
+	// WithCancel arranges for Done to be closed when cancel is called;
+	// WithDeadline arranges for Done to be closed when the deadline
+	// expires; WithTimeout arranges for Done to be closed when the timeout
+	// elapses.
+	//
+	// Done is provided for use in select statements:
+	//
+	//  // Stream generates values with DoSomething and sends them to out
+	//  // until DoSomething returns an error or ctx.Done is closed.
+	//  func Stream(ctx context.Context, out chan<- Value) error {
+	//  	for {
+	//  		v, err := DoSomething(ctx)
+	//  		if err != nil {
+	//  			return err
+	//  		}
+	//  		select {
+	//  		case <-ctx.Done():
+	//  			return ctx.Err()
+	//  		case out <- v:
+	//  		}
+	//  	}
+	//  }
+	//
+	// See https://blog.golang.org/pipelines for more examples of how to use
+	// a Done channel for cancelation.
+	Done() <-chan struct{}
+
+	// Err returns a non-nil error value after Done is closed. Err returns
+	// Canceled if the context was canceled or DeadlineExceeded if the
+	// context's deadline passed. No other values for Err are defined.
+	// After Done is closed, successive calls to Err return the same value.
+	Err() error
+
+	// Value returns the value associated with this context for key, or nil
+	// if no value is associated with key. Successive calls to Value with
+	// the same key returns the same result.
+	//
+	// Use context values only for request-scoped data that transits
+	// processes and API boundaries, not for passing optional parameters to
+	// functions.
+	//
+	// A key identifies a specific value in a Context. Functions that wish
+	// to store values in Context typically allocate a key in a global
+	// variable then use that key as the argument to context.WithValue and
+	// Context.Value. A key can be any type that supports equality;
+	// packages should define keys as an unexported type to avoid
+	// collisions.
+	//
+	// Packages that define a Context key should provide type-safe accessors
+	// for the values stored using that key:
+	//
+	// 	// Package user defines a User type that's stored in Contexts.
+	// 	package user
+	//
+	// 	import "context"
+	//
+	// 	// User is the type of value stored in the Contexts.
+	// 	type User struct {...}
+	//
+	// 	// key is an unexported type for keys defined in this package.
+	// 	// This prevents collisions with keys defined in other packages.
+	// 	type key int
+	//
+	// 	// userKey is the key for user.User values in Contexts. It is
+	// 	// unexported; clients use user.NewContext and user.FromContext
+	// 	// instead of using this key directly.
+	// 	var userKey key = 0
+	//
+	// 	// NewContext returns a new Context that carries value u.
+	// 	func NewContext(ctx context.Context, u *User) context.Context {
+	// 		return context.WithValue(ctx, userKey, u)
+	// 	}
+	//
+	// 	// FromContext returns the User value stored in ctx, if any.
+	// 	func FromContext(ctx context.Context) (*User, bool) {
+	// 		u, ok := ctx.Value(userKey).(*User)
+	// 		return u, ok
+	// 	}
+	Value(key interface{}) interface{}
+}

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -151,10 +151,10 @@ func TestExperiment_Run_WithContext(t *testing.T) {
 }
 
 func TestExperiment_Run_Before(t *testing.T) {
-	beforeFunc := func(ctx context.Context) context.Context {
+	beforeFunc := func(ctx Context) Context {
 		return context.WithValue(ctx, "my-key", "my-value")
 	}
-	checkFunc := func(ctx context.Context) (interface{}, error) {
+	checkFunc := func(ctx Context) (interface{}, error) {
 		if exp, val := "my-value", ctx.Value("my-key").(string); exp != val {
 			t.Fatalf("Expected context string to be `%s`, got `%s`", exp, val)
 		}
@@ -246,23 +246,23 @@ func newExperiment(cfg Config) *Experiment {
 	}
 }
 
-func dummyContextTestFunc(ctx context.Context) (interface{}, error) {
+func dummyContextTestFunc(ctx Context) (interface{}, error) {
 	return ctx.Value("ctx-test"), nil
 }
 
-func dummyTestFunc(ctx context.Context) (interface{}, error) {
+func dummyTestFunc(ctx Context) (interface{}, error) {
 	return "test", nil
 }
 
-func dummyControlFunc(ctx context.Context) (interface{}, error) {
+func dummyControlFunc(ctx Context) (interface{}, error) {
 	return "control", nil
 }
 
-func dummyTestErrorFunc(ctx context.Context) (interface{}, error) {
+func dummyTestErrorFunc(ctx Context) (interface{}, error) {
 	return "test", errors.New("error")
 }
 
-func dummyTestPanicFunc(ctx context.Context) (interface{}, error) {
+func dummyTestPanicFunc(ctx Context) (interface{}, error) {
 	panic("test")
 	return "panic", nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,0 @@
-hash: f8b4afc43f7bb0164e8e6c3ee3be88f60784fd40a456490cca5fa153df6acbd2
-updated: 2016-08-17T00:00:58.660684281+01:00
-imports:
-- name: golang.org/x/net
-  version: 07b51741c1d6423d4a6abab1c49940ec09cb1aaf
-  subpackages:
-  - context
-testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,0 @@
-package: github.com/jelmersnoeck/experiment
-import:
-- package: golang.org/x/net
-  subpackages:
-  - context

--- a/result_test.go
+++ b/result_test.go
@@ -3,8 +3,6 @@ package experiment_test
 import (
 	"testing"
 
-	"golang.org/x/net/context"
-
 	"github.com/jelmersnoeck/experiment"
 )
 
@@ -40,15 +38,15 @@ func testObservations() experiment.Observations {
 	}
 }
 
-func dummyTestFunc(ctx context.Context) (interface{}, error) {
+func dummyTestFunc(ctx experiment.Context) (interface{}, error) {
 	return "test", nil
 }
 
-func dummyCompareTestFunc(ctx context.Context) (interface{}, error) {
+func dummyCompareTestFunc(ctx experiment.Context) (interface{}, error) {
 	return "control", nil
 }
 
-func dummyControlFunc(ctx context.Context) (interface{}, error) {
+func dummyControlFunc(ctx experiment.Context) (interface{}, error) {
 	return "control", nil
 }
 

--- a/runner.go
+++ b/runner.go
@@ -1,10 +1,6 @@
 package experiment
 
-import (
-	"time"
-
-	"golang.org/x/net/context"
-)
+import "time"
 
 // Runner represents the implementation that actually runs the tests. Runners
 // are not safe for concurrent use. Each concurrent request should request
@@ -42,11 +38,7 @@ func (r *Runner) HasRun() bool {
 }
 
 // Run will run the tests with a given context.
-func (r *Runner) Run(ctx context.Context) Observations {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
+func (r *Runner) Run(ctx Context) Observations {
 	for _, f := range r.config.BeforeFilters {
 		ctx = f(ctx)
 	}
@@ -106,7 +98,7 @@ func (r *Runner) shouldRun() bool {
 	return false
 }
 
-func (r *Runner) observe(ctx context.Context, beh *behaviour, obsch chan *Observation, tm bool) {
+func (r *Runner) observe(ctx Context, beh *behaviour, obsch chan *Observation, tm bool) {
 	obs := &Observation{Name: beh.name}
 
 	defer func() {
@@ -126,7 +118,7 @@ func (r *Runner) observe(ctx context.Context, beh *behaviour, obsch chan *Observ
 	runObservation(ctx, beh, obs)
 }
 
-func runObservation(ctx context.Context, b *behaviour, obs *Observation) {
+func runObservation(ctx Context, b *behaviour, obs *Observation) {
 	defer func(start time.Time) {
 		obs.Duration = time.Now().Sub(start)
 	}(time.Now())


### PR DESCRIPTION
This removes the external dependency of the `/x/net/context` package.
Due to backwards compability reasons, the interface has been copied to
the package. We want to support Go versions below 1.7.

The package now also expects the context to be actually set and won't
create a default if this is not the case. The Go Context package that
one should use a `context.TODO()` when it is unclear which context to
use. The end user should now properly implement this behaviour.