### PR TITLE
Add control clean value to candidate observations

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -217,6 +217,7 @@ func (e *Experiment) conclude() {
 				o.CleanValue = o.Value
 			}
 		}
+		o.ControlValue = control.CleanValue
 	}
 
 	if e.Config.Publisher != nil {

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -54,7 +54,20 @@ func TestRun_Sequential(t *testing.T) {
 		exp.Run()
 	})
 
-	t.Run("it should record the clean", func(t *testing.T) {
+	t.Run("it should record the clean control", func(t *testing.T) {
+		pub.fnc = func(o experiment.Observation) {
+			if o.Name != "control" {
+				fmt.Printf("%+v\n", o)
+				if o.Panic == nil && o.ControlValue.(string) != "Cleaned control" {
+					t.Errorf("Expected value to be '%s', got '%s'", "Cleaned Control", o.ControlValue.(string))
+				}
+			}
+		}
+
+		exp.Run()
+	})
+
+	t.Run("it should record the clean control value", func(t *testing.T) {
 		pub.fnc = func(o experiment.Observation) {
 			if o.Panic == nil && o.Error == nil && o.Success {
 				cleaned := fmt.Sprintf("Cleaned %s", o.Value.(string))

--- a/observation.go
+++ b/observation.go
@@ -4,11 +4,12 @@ import "time"
 
 // Observation represents the outcome of a candidate that has run.
 type Observation struct {
-	Duration   time.Duration
-	Error      error
-	Success    bool
-	Name       string
-	Panic      interface{}
-	Value      interface{}
-	CleanValue interface{}
+	Duration     time.Duration
+	Error        error
+	Success      bool
+	Name         string
+	Panic        interface{}
+	Value        interface{}
+	CleanValue   interface{}
+	ControlValue interface{}
 }


### PR DESCRIPTION
Add control value to candidate observations so that you can cover several scenarios like: 
* Publish results only if the candidate wasn't successful (to not cluttered your tool with positive results).
* Publish a diff of candidate and control results. 