### PR TITLE
Fix bug in ControlValue

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -196,6 +196,16 @@ func (e *Experiment) runSequential(cChan chan *Observation) {
 func (e *Experiment) conclude() {
 	control := e.observations["control"]
 
+	for _, o := range e.observations {
+		if o.Error == nil {
+			if e.clean != nil {
+				o.CleanValue = e.clean(o.Value)
+			} else {
+				o.CleanValue = o.Value
+			}
+		}
+	}
+
 	if e.compare != nil {
 		for k, o := range e.observations {
 			if o.Error == nil {
@@ -205,19 +215,9 @@ func (e *Experiment) conclude() {
 				}
 
 				o.Success = e.compare(control.Value, o.Value)
+				o.ControlValue = control.CleanValue
 			}
 		}
-	}
-
-	for _, o := range e.observations {
-		if o.Error == nil {
-			if e.clean != nil {
-				o.CleanValue = e.clean(o.Value)
-			} else {
-				o.CleanValue = o.Value
-			}
-		}
-		o.ControlValue = control.CleanValue
 	}
 
 	if e.Config.Publisher != nil {

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -56,8 +56,7 @@ func TestRun_Sequential(t *testing.T) {
 
 	t.Run("it should record the clean control", func(t *testing.T) {
 		pub.fnc = func(o experiment.Observation) {
-			if o.Name != "control" {
-				fmt.Printf("%+v\n", o)
+			if o.Name != "control" && o.Error == nil {
 				if o.Panic == nil && o.ControlValue.(string) != "Cleaned control" {
 					t.Errorf("Expected value to be '%s', got '%s'", "Cleaned Control", o.ControlValue.(string))
 				}


### PR DESCRIPTION
I introduced a bug with my previous PR, this should fix it. 

Basically, you have to set the CleanValue of control beforehand, so that it can be set in each candidate observation. 

Apologies for the problem I introduced. 