### PR TITLE
Use generics to replace all interfaces.

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,29 +3,21 @@ package experiment
 // Config represents the configuration options for an experiment.
 type Config struct {
 	Percentage  int
-	Publisher   Publisher
 	Concurrency bool
-}
-
-// Publisher represents an interface that allows you to publish results.
-type Publisher interface {
-	Publish(Observation)
 }
 
 // ConfigFunc represents a function that knows how to set a configuration option.
 type ConfigFunc func(*Config)
 
-// WithPercentage returns a new ConfigFunc that sets the percentage.
+// Publisher represents an interface that allows you to publish results.
+type Publisher[C any] interface {
+	Publish(Observation[C])
+}
+
+// WithPercentage returns a new func(*Config) that sets the percentage.
 func WithPercentage(p int) ConfigFunc {
 	return func(c *Config) {
 		c.Percentage = p
-	}
-}
-
-// WithPublisher returns a new ConfigFunc that sets the publisher.
-func WithPublisher(p Publisher) ConfigFunc {
-	return func(c *Config) {
-		c.Publisher = p
 	}
 }
 
@@ -41,6 +33,5 @@ func WithDefaultConfig() ConfigFunc {
 	return func(c *Config) {
 		c.Percentage = 0
 		c.Concurrency = false
-		c.Publisher = nil
 	}
 }

--- a/observation.go
+++ b/observation.go
@@ -3,13 +3,13 @@ package experiment
 import "time"
 
 // Observation represents the outcome of a candidate that has run.
-type Observation struct {
+type Observation[C any] struct {
 	Duration     time.Duration
 	Error        error
 	Success      bool
 	Name         string
 	Panic        interface{}
-	Value        interface{}
-	CleanValue   interface{}
-	ControlValue interface{}
+	Value        C
+	CleanValue   C
+	ControlValue C
 }

--- a/publisher.go
+++ b/publisher.go
@@ -8,8 +8,8 @@ type Logger interface {
 }
 
 // NewLogPublisher returns a new LogPublisher.
-func NewLogPublisher(name string, logger Logger) *LogPublisher {
-	return &LogPublisher{
+func NewLogPublisher[C any](name string, logger Logger) *LogPublisher[C] {
+	return &LogPublisher[C]{
 		Name:   name,
 		Logger: logger,
 	}
@@ -17,7 +17,7 @@ func NewLogPublisher(name string, logger Logger) *LogPublisher {
 
 // LogPublisher is a publisher that writes out the observation values as a log
 // line. If no Logger is provided, the standard library logger will be used.
-type LogPublisher struct {
+type LogPublisher[C any] struct {
 	Name   string
 	Logger Logger
 }
@@ -25,7 +25,7 @@ type LogPublisher struct {
 // Publish will publish all the Observation variables as a log line. It is in
 // the following format:
 // [Experiment Observation] name=%s duration=%s success=%t value=%v error=%v
-func (l *LogPublisher) Publish(o Observation) {
+func (l *LogPublisher[C]) Publish(o Observation[C]) {
 	msg := "[Experiment Observation: %s] name=%s duration=%s success=%t value=%v error=%v"
 	args := []interface{}{l.Name, o.Name, o.Duration, o.Success, o.CleanValue, o.Error}
 	if l.Logger == nil {

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -7,11 +7,10 @@ import (
 )
 
 func ExampleLogPublisher() {
-	exp := experiment.New(
-		experiment.WithPublisher(experiment.NewLogPublisher("publisher", &fmtLogger{})),
-	)
+	exp := experiment.New[string]().
+		WithPublisher(experiment.NewLogPublisher[string]("publisher", &fmtLogger{}))
 
-	exp.Control(func() (interface{}, error) {
+	exp.Control(func() (string, error) {
 		return "Hello world!", nil
 	})
 
@@ -19,7 +18,7 @@ func ExampleLogPublisher() {
 	if err != nil {
 		panic(err)
 	} else {
-		fmt.Println(result.(string))
+		fmt.Println(result)
 	}
 
 	// Output: Hello world!


### PR DESCRIPTION
Go added support for generics in 1.18. This converts the experiment
package to use generics to be more flexible.
