### PR TITLE
Streamline error handling.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,14 @@
+package experiment
+
+import "fmt"
+
+// ErrCandidatePanic represents the error that a candidate panicked.
+type CandidatePanicError struct {
+	Name  string
+	Panic interface{}
+}
+
+// Error returns a simple error message. It does not include the panic information.
+func (e CandidatePanicError) Error() string {
+	return fmt.Sprintf("experiment candidate '%s' panicked", e.Name)
+}

--- a/experiment.go
+++ b/experiment.go
@@ -1,7 +1,6 @@
 package experiment
 
 import (
-	"errors"
 	"math/rand"
 	"time"
 )
@@ -24,15 +23,6 @@ type (
 	// how to compare them. The functionality is implemented by the user. This
 	// function will only be called for candidates that did not error.
 	CompareFunc[C any] func(C, C) bool
-)
-
-var (
-	// ErrControlCandidate is returned when a candidate is initiated with
-	// control as it's name.
-	ErrControlCandidate = errors.New("can't use a candidate with the name 'control'")
-
-	// ErrCandidatePanic represents the error that a candidate panicked.
-	ErrCandidatePanic = errors.New("candidate panicked")
 )
 
 // Experiment represents a new refactoring experiment. This is where you'll
@@ -98,7 +88,7 @@ func (e *Experiment[C]) Control(fnc CandidateFunc[C]) {
 // If the name is control, this will panic.
 func (e *Experiment[C]) Candidate(name string, fnc CandidateFunc[C]) error {
 	if name == "control" {
-		return ErrControlCandidate
+		panic("can't use a candidate with the name 'control'")
 	}
 
 	e.candidates[name] = fnc
@@ -248,9 +238,11 @@ func runCandidate[C any](name string, fnc CandidateFunc[C], obsChan chan *Observ
 			end := time.Now()
 
 			obsChan <- &Observation[C]{
-				Name:     name,
-				Panic:    r,
-				Error:    ErrCandidatePanic,
+				Name: name,
+				Error: CandidatePanicError{
+					Name:  name,
+					Panic: r,
+				},
 				Duration: end.Sub(start),
 			}
 		}

--- a/observation.go
+++ b/observation.go
@@ -8,7 +8,6 @@ type Observation[C any] struct {
 	Error        error
 	Success      bool
 	Name         string
-	Panic        interface{}
 	Value        C
 	CleanValue   C
 	ControlValue C


### PR DESCRIPTION
Before, Control and Candidate were differentiated by their return value.
Candidate functions could return an error only if the name was
'control'. This now panics for that, as it is a developer error which we
want to highlight as soon as possible and is not recoverable.

This also introduces struct errors so it can leverage errors.Is and
errors.As properly.
