### PR TITLE
Make experiments context aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ func main() {
 	// fetch arbitrary data
 	userData := getUserData()
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return dataToPng.Render(userData)
 	})
 
-	exp.Candidate("", func() (string, error) {
+	exp.Candidate("", func(context.Context) (string, error) {
 		return imageX.Render(userData)
 	})
 
-	result, err := exp.Run()
+	result, err := exp.Run(context.Background())
 }
 ```
 
@@ -52,9 +52,9 @@ about your new implementation.
 
 ### Control
 
-`Control(func() (any, error))` should be used to implement your current
-code. The result of this will be used to compare to other candidates. This will
-run as it would run normally.
+`Control(func(context.Context) (any, error))` should be used to implement your
+current code. The result of this will be used to compare to other candidates.
+This will run as it would run normally.
 
 A control is always expected. If no control is provided, the experiment will
 panic.
@@ -65,11 +65,11 @@ func main() {
 		experiment.WithPercentage(50),
 	)
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return fmt.Sprintf("Hello world!"), nil
 	})
 
-	result, err := exp.Run()
+	result, err := exp.Run(context.Background())
 	if err != nil {
 		panic(err)
 	} else {
@@ -82,9 +82,9 @@ The example above will always print `Hello world!`.
 
 ### Candidate
 
-`Candidate(string, func() (any, error))` is a potential refactored
-candidate. This will run sandboxed, meaning that when this panics, the panic
-is captured and the experiment continues.
+`Candidate(string, func(context.Context) (any, error))` is a potential
+refactored candidate. This will run sandboxed, meaning that when this panics,
+the panic is captured and the experiment continues.
 
 A candidate will not always run, this depends on the `WithPercentage(int)`
 configuration option and further overrides.
@@ -95,15 +95,15 @@ func main() {
 		experiment.WithPercentage(50),
 	)
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return fmt.Sprintf("Hello world!"), nil
 	})
 
-	exp.Candidate("candidate1", func() (string, error) {
+	exp.Candidate("candidate1", func(context.Context) (string, error) {
 		return "Hello candidate", nil
 	})
 
-	result, err := exp.Run()
+	result, err := exp.Run(context.Background())
 	if err != nil {
 		panic(err)
 	} else {
@@ -117,9 +117,9 @@ function will however run in the background 50% of the time.
 
 ### Run
 
-`Run()` will run the experiment and return the value and error of the control
+`Run(context.Context)` will run the experiment and return the value and error of the control
 function. The control function is always executed. The result value of the
-`Run()` function is an interface. The user should cast this to the expected
+`Run(context.Context)` function is an interface. The user should cast this to the expected
 type.
 
 ### Force
@@ -184,8 +184,9 @@ is also an `Error` attribute available, which contains the error returned.
 
 ### Regular errors
 
-When the control errors, this will be returned in the `Run()` method. When a
-candidate errors, this will be attached to the `Error` field in its observation.
+When the control errors, this will be returned in the `Run(context.Context)`
+method. When a candidate errors, this will be attached to the `Error` field in
+its observation.
 
 An error marks the experiment as a failure.
 
@@ -239,17 +240,17 @@ func main() {
 		experiment.WithPercentage(50),
 	).WithPublisher(experiment.NewLogPublisher[string]("publisher", nil))
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return fmt.Sprintf("Hello world!"), nil
 	})
 
-	exp.Candidate("candidate1", func() (string, error) {
+	exp.Candidate("candidate1", func(context.Context) (string, error) {
 		return "Hello candidate", nil
 	})
 
 	exp.Force(true)
 
-	result, err := exp.Run()
+	result, err := exp.Run(context.Context)
 	if err != nil {
 		panic(err)
 	} else {

--- a/config.go
+++ b/config.go
@@ -1,23 +1,27 @@
 package experiment
 
+import "time"
+
 // Config represents the configuration options for an experiment.
 type Config struct {
 	Percentage  int
 	Concurrency bool
+	Timeout     *time.Duration
 }
 
 // ConfigFunc represents a function that knows how to set a configuration option.
 type ConfigFunc func(*Config)
 
-// Publisher represents an interface that allows you to publish results.
-type Publisher[C any] interface {
-	Publish(Observation[C])
-}
-
 // WithPercentage returns a new func(*Config) that sets the percentage.
 func WithPercentage(p int) ConfigFunc {
 	return func(c *Config) {
 		c.Percentage = p
+	}
+}
+
+func WithTimeout(t time.Duration) ConfigFunc {
+	return func(c *Config) {
+		c.Timeout = &t
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -12,3 +12,30 @@ type CandidatePanicError struct {
 func (e CandidatePanicError) Error() string {
 	return fmt.Sprintf("experiment candidate '%s' panicked", e.Name)
 }
+
+// PublishError is an error used when the publisher returns an error. It
+// combines all errors into a single error.
+type PublishError struct {
+	errors []error
+}
+
+func (e *PublishError) Error() string {
+	var b []byte
+	for i, err := range e.errors {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+func (e *PublishError) Unwrap() []error {
+	return e.errors
+}
+
+func (e *PublishError) append(err error) {
+	if err != nil {
+		e.errors = append(e.errors, err)
+	}
+}

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -11,83 +11,131 @@ import (
 	"github.com/jelmersnoeck/experiment"
 )
 
-func TestRun_Sequential(t *testing.T) {
-	exp, pub := testExperiment()
+func TestRun(t *testing.T) {
+	t.Run("sequential", func(t *testing.T) {
+		t.Run("basic", func(t *testing.T) {
+			testRun(t)
+		})
 
-	t.Run("it should record a success", func(t *testing.T) {
-		pub.fnc = func(o experiment.Observation[string]) {
-			if o.Name == "correct" && !o.Success {
-				t.Errorf("Expected a success, got mismatch")
-			}
-		}
-
-		exp.Run()
+		t.Run("timeouts", func(t *testing.T) {
+			testWithTimeout(t)
+		})
 	})
 
-	t.Run("it should record a mismatch", func(t *testing.T) {
-		pub.fnc = func(o experiment.Observation[string]) {
-			if o.Name == "mismatch" && o.Success {
-				t.Errorf("Expected a mismatch, got success")
-			}
+	t.Run("concurrent", func(t *testing.T) {
+		t.Run("basic", func(t *testing.T) {
+			testRun(t, experiment.WithConcurrency())
+		})
+
+		t.Run("timeouts", func(t *testing.T) {
+			testWithTimeout(t, experiment.WithConcurrency())
+		})
+	})
+}
+
+func testRun(t *testing.T, config ...experiment.ConfigFunc) {
+	t.Run("it should record", func(t *testing.T) {
+		tcs := map[string]struct {
+			pubFunc func(context.Context, experiment.Observation[string]) error
+		}{
+			"a success": {
+				pubFunc: func(_ context.Context, o experiment.Observation[string]) error {
+					if o.Name == "correct" && !o.Success {
+						t.Errorf("Expected a success, got mismatch")
+					}
+
+					return nil
+				},
+			},
+			"a mismatch": {
+				pubFunc: func(_ context.Context, o experiment.Observation[string]) error {
+					if o.Name == "mismatch" && o.Success {
+						t.Errorf("Expected a mismatch, got success")
+					}
+
+					return nil
+				},
+			},
+			"an error": {
+				pubFunc: func(_ context.Context, o experiment.Observation[string]) error {
+					if o.Name == "error" && o.Error == nil {
+						t.Errorf("Expected an error, got none")
+					}
+
+					return nil
+				},
+			},
+			"the panic in the CandidatePanicError": {
+				pubFunc: func(_ context.Context, o experiment.Observation[string]) error {
+					if o.Name == "panic" {
+						var panicError experiment.CandidatePanicError
+						if !errors.As(o.Error, &panicError) {
+							t.Errorf("Expected CandidatePanicError, got %T", o.Error)
+						}
+
+						if panicError.Panic == nil {
+							t.Errorf("Expected a panic, did not record one")
+						}
+					}
+
+					return nil
+				},
+			},
+			"the clean control": {
+				pubFunc: func(_ context.Context, o experiment.Observation[string]) error {
+					if o.Name != "control" && o.Error == nil {
+						if o.ControlValue != "Cleaned control" {
+							t.Errorf("Expected value to be '%s', got '%s'", "Cleaned Control", o.ControlValue)
+						}
+					}
+
+					return nil
+				},
+			},
+			"the clean control value": {
+				pubFunc: func(_ context.Context, o experiment.Observation[string]) error {
+					if o.Error == nil && o.Success {
+						cleaned := fmt.Sprintf("Cleaned %s", o.Value)
+						if o.CleanValue != cleaned {
+							t.Errorf("Expected value to be '%s', got '%s'", cleaned, o.CleanValue)
+						}
+					}
+
+					return nil
+				},
+			},
 		}
 
-		exp.Run()
-	})
+		for name, tc := range tcs {
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+				exp, pub := testExperiment(config...)
 
-	t.Run("it should record an error", func(t *testing.T) {
-		pub.fnc = func(o experiment.Observation[string]) {
-			if o.Name == "error" && o.Error == nil {
-				t.Errorf("Expected an error, got none")
-			}
-		}
-
-		exp.Run()
-	})
-
-	t.Run("it should record the panic in the CandidatePanicError", func(t *testing.T) {
-		pub.fnc = func(o experiment.Observation[string]) {
-			if o.Name == "panic" {
-				var panicError experiment.CandidatePanicError
-				if !errors.As(o.Error, &panicError) {
-					t.Errorf("Expected CandidatePanicError, got %T", o.Error)
+				var pubRun bool
+				pub.fnc = func(ctx context.Context, o experiment.Observation[string]) error {
+					pubRun = true
+					return tc.pubFunc(ctx, o)
 				}
 
-				if panicError.Panic == nil {
-					t.Errorf("Expected a panic, did not record one")
+				if _, err := exp.Run(ctx); err != nil {
+					t.Errorf("Expected no error for running, got %s", err)
 				}
-			}
-		}
 
-		exp.Run()
-	})
-
-	t.Run("it should record the clean control", func(t *testing.T) {
-		pub.fnc = func(o experiment.Observation[string]) {
-			if o.Name != "control" && o.Error == nil {
-				if o.ControlValue != "Cleaned control" {
-					t.Errorf("Expected value to be '%s', got '%s'", "Cleaned Control", o.ControlValue)
+				if err := exp.Publish(ctx); err != nil {
+					t.Errorf("Expected no error for publishing, got %s", err)
 				}
-			}
-		}
 
-		exp.Run()
-	})
-
-	t.Run("it should record the clean control value", func(t *testing.T) {
-		pub.fnc = func(o experiment.Observation[string]) {
-			if o.Error == nil && o.Success {
-				cleaned := fmt.Sprintf("Cleaned %s", o.Value)
-				if o.CleanValue != cleaned {
-					t.Errorf("Expected value to be '%s', got '%s'", cleaned, o.CleanValue)
+				if pubRun != true {
+					t.Error("Expected publisher to run, it did not")
 				}
-			}
+			})
 		}
-
-		exp.Run()
 	})
 
 	t.Run("it should return the correct value", func(t *testing.T) {
-		val, err := exp.Run()
+		ctx := context.Background()
+		exp, _ := testExperiment(config...)
+		val, err := exp.Run(ctx)
 		if val != "control" {
 			t.Errorf("Expected value to be 'control', got '%s'", val)
 		}
@@ -99,20 +147,21 @@ func TestRun_Sequential(t *testing.T) {
 }
 
 func TestRun_Before(t *testing.T) {
+	ctx := context.Background()
 	exp := experiment.New[string]()
 	exp.Force(true)
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return "", nil
 	})
 
 	t.Run("with an error", func(t *testing.T) {
 		expected := errors.New("before error")
-		exp.Before(func() error {
+		exp.Before(func(context.Context) error {
 			return expected
 		})
 
-		_, err := exp.Run()
+		_, err := exp.Run(ctx)
 		if expected != err {
 			t.Errorf("Expected error '%v', got '%v'", expected, err)
 		}
@@ -120,12 +169,12 @@ func TestRun_Before(t *testing.T) {
 
 	t.Run("without an error", func(t *testing.T) {
 		var ran bool
-		exp.Before(func() error {
+		exp.Before(func(context.Context) error {
 			ran = true
 			return nil
 		})
 
-		exp.Run()
+		exp.Run(ctx)
 		if !ran {
 			t.Errorf("Expected before to have run, did not")
 		}
@@ -138,37 +187,224 @@ func TestRun_Ignore(t *testing.T) {
 
 	var count int
 	var lock sync.Mutex
-	pub.fnc = func(_ experiment.Observation[string]) {
+	pub.fnc = func(_ context.Context, _ experiment.Observation[string]) error {
 		lock.Lock()
 		defer lock.Unlock()
 		count++
+		return nil
 	}
 
-	exp.Run()
+	exp.Run(context.Background())
 
 	if count != 0 {
 		t.Errorf("Expected '0' observations, got '%d'", count)
 	}
 }
 
-func TestRun_Concurrent(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+func testWithTimeout(t *testing.T, o ...experiment.ConfigFunc) {
+	contextTimeout := 10 * time.Millisecond
+	timeFunc := func(ctx context.Context, dur time.Duration) error {
+		tick := time.NewTicker(dur)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tick.C:
+			return nil
+		}
+	}
 
-	exp, pub := testExperiment(experiment.WithConcurrency())
-	expected := 5
-	eChan := make(chan bool)
+	t.Run("with slow control", func(t *testing.T) {
+		exp := experiment.New[string](o...)
+		exp.Force(true)
+
+		var hasRun bool
+		exp.Control(func(ctx context.Context) (string, error) {
+			hasRun = true
+			return "", timeFunc(ctx, time.Minute)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+		defer cancel()
+		_, err := exp.Run(ctx)
+
+		if !hasRun {
+			t.Errorf("expected control to have run")
+		}
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("expected deadline exceeded")
+		}
+	})
+
+	t.Run("with slow candidate", func(t *testing.T) {
+		pub := &testPublisher[string]{}
+		exp := experiment.New[string](o...).WithPublisher(pub)
+		exp.Force(true)
+
+		var hasRun bool
+		exp.Control(func(ctx context.Context) (string, error) {
+			return "", nil
+		})
+
+		exp.Candidate("candidate", func(ctx context.Context) (string, error) {
+			hasRun = true
+			return "", timeFunc(ctx, time.Minute)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+		defer cancel()
+		_, err := exp.Run(ctx)
+
+		if !hasRun {
+			t.Errorf("expected candidate to have run")
+		}
+
+		if err != nil {
+			t.Errorf("expected no error from the control function, got %s", err)
+		}
+
+		// time.Sleep(time.Second)
+		var candidateErr error
+		pub.fnc = func(_ context.Context, o experiment.Observation[string]) error {
+			if o.Name == "candidate" {
+				candidateErr = o.Error
+			}
+			return nil
+		}
+
+		if err := exp.Publish(context.Background()); err != nil {
+			t.Errorf("expected publishing to succeed, got error %s", err)
+		}
+
+		if !errors.Is(candidateErr, context.DeadlineExceeded) {
+			t.Errorf("expected candidate to have exceeded the deadline, got %s error", candidateErr)
+		}
+	})
+
+	t.Run("with everything timely", func(t *testing.T) {
+		pub := &testPublisher[string]{}
+		exp := experiment.New[string](o...).WithPublisher(pub)
+		exp.Force(true)
+
+		var hasRun bool
+		exp.Control(func(ctx context.Context) (string, error) {
+			return "", nil
+		})
+
+		exp.Candidate("candidate", func(ctx context.Context) (string, error) {
+			hasRun = true
+			return "", nil
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+		defer cancel()
+		_, err := exp.Run(ctx)
+
+		if !hasRun {
+			t.Errorf("expected candidate to have run")
+		}
+
+		if err != nil {
+			t.Errorf("expected no error from the control function, got %s", err)
+		}
+
+		var candidateErr error
+		pub.fnc = func(_ context.Context, o experiment.Observation[string]) error {
+			if o.Name == "candidate" {
+				candidateErr = o.Error
+			}
+			return nil
+		}
+
+		if err := exp.Publish(context.Background()); err != nil {
+			t.Errorf("expected publishing to succeed, got error %s", err)
+		}
+
+		if candidateErr != nil {
+			t.Errorf("expected no candidate error, got %s", candidateErr)
+		}
+	})
+}
+
+func TestRun_ContextPropagation(t *testing.T) {
+	exp := experiment.New[string](experiment.WithTimeout(time.Second))
+	exp.Force(true)
+
+	key := func(s string) *string { return &s }("key")
+
+	exp.Control(func(ctx context.Context) (string, error) {
+		if value := ctx.Value(key); value != "value" {
+			t.Errorf("expected context key to have value, got %s", value)
+		}
+		return "", nil
+	})
+
+	exp.Candidate("candidate", func(ctx context.Context) (string, error) {
+		if value := ctx.Value(key); value != "value" {
+			t.Errorf("expected context key to have value, got %s", value)
+		}
+		return "", nil
+	})
+
+	ctx := context.WithValue(context.Background(), key, "value")
+	_, err := exp.Run(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+}
+
+func TestRun_WithConcurrency(t *testing.T) {
+	exp := experiment.New[string]()
+	exp.Force(true)
 
 	var count int
 	var lock sync.Mutex
-	pub.fnc = func(o experiment.Observation[string]) {
+
+	expected := 5
+	eChan := make(chan bool)
+
+	fnc := func(name string) experiment.CandidateFunc[string] {
+		return func(context.Context) (string, error) {
+			lock.Lock()
+			defer lock.Unlock()
+			count++
+			eChan <- true
+			return name, nil
+		}
+	}
+
+	exp.Control(fnc("control"))
+
+	exp.Candidate("correct", fnc("correct"))
+
+	exp.Candidate("mismatch", fnc("mismatch"))
+
+	exp.Candidate("error", func(context.Context) (string, error) {
 		lock.Lock()
 		defer lock.Unlock()
 		count++
 		eChan <- true
-	}
+		return "", errors.New("errored")
+	})
 
-	exp.Run()
+	exp.Candidate("panic", func(context.Context) (string, error) {
+		lock.Lock()
+		defer lock.Unlock()
+		count++
+		eChan <- true
+		panic("candidate")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// run this in a goroutine so we can check for the messages coming in on the
+	// eChan channel.
+	go func() {
+		if _, err := exp.Run(ctx); err != nil {
+			t.Errorf("Expected no error running, got %s", err)
+		}
+	}()
 
 checkLoop:
 	for i := 0; i < expected; i++ {
@@ -185,29 +421,65 @@ checkLoop:
 	}
 }
 
+func TestPublish_Errors(t *testing.T) {
+	pub := &testPublisher[string]{}
+	pub.fnc = func(ctx context.Context, o experiment.Observation[string]) error {
+		return errors.New(o.Name)
+	}
+
+	exp := experiment.New[string]().WithPublisher(pub)
+	exp.Force(true)
+
+	exp.Control(func(context.Context) (string, error) {
+		return "control", nil
+	})
+
+	exp.Candidate("correct", func(context.Context) (string, error) {
+		return "control", nil
+	})
+
+	exp.Candidate("mismatch", func(context.Context) (string, error) {
+		return "mismatch", nil
+	})
+
+	ctx := context.Background()
+	if _, err := exp.Run(ctx); err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+
+	var publishErr *experiment.PublishError
+	if err := exp.Publish(ctx); !errors.As(err, &publishErr) {
+		t.Errorf("Expected PublishError error, got %s", err)
+	}
+
+	if len := len(publishErr.Unwrap()); len != 3 {
+		t.Errorf("Expected 3 errors, got %d", len)
+	}
+}
+
 func testExperiment(cfg ...experiment.ConfigFunc) (*experiment.Experiment[string], *testPublisher[string]) {
 	pub := &testPublisher[string]{}
 
 	exp := experiment.New[string](cfg...).WithPublisher(pub)
 	exp.Force(true)
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return "control", nil
 	})
 
-	exp.Candidate("correct", func() (string, error) {
+	exp.Candidate("correct", func(context.Context) (string, error) {
 		return "control", nil
 	})
 
-	exp.Candidate("mismatch", func() (string, error) {
+	exp.Candidate("mismatch", func(context.Context) (string, error) {
 		return "mismatch", nil
 	})
 
-	exp.Candidate("error", func() (string, error) {
+	exp.Candidate("error", func(context.Context) (string, error) {
 		return "", errors.New("errored")
 	})
 
-	exp.Candidate("panic", func() (string, error) {
+	exp.Candidate("panic", func(context.Context) (string, error) {
 		panic("candidate")
 	})
 
@@ -220,15 +492,16 @@ func testExperiment(cfg ...experiment.ConfigFunc) (*experiment.Experiment[string
 	})
 
 	return exp, pub
-
 }
 
 type testPublisher[C any] struct {
-	fnc func(experiment.Observation[C])
+	fnc func(context.Context, experiment.Observation[C]) error
 }
 
-func (t *testPublisher[C]) Publish(o experiment.Observation[C]) {
+func (t *testPublisher[C]) Publish(ctx context.Context, o experiment.Observation[C]) error {
 	if t.fnc != nil {
-		t.fnc(o)
+		return t.fnc(ctx, o)
 	}
+
+	return nil
 }

--- a/publisher.go
+++ b/publisher.go
@@ -1,10 +1,18 @@
 package experiment
 
-import "log"
+import (
+	"context"
+	"log"
+)
 
 // Logger represents the interface that experiment expects for a logger.
 type Logger interface {
 	Printf(string, ...interface{})
+}
+
+// Publisher represents an interface that allows you to publish results.
+type Publisher[C any] interface {
+	Publish(context.Context, Observation[C]) error
 }
 
 // NewLogPublisher returns a new LogPublisher.
@@ -25,7 +33,7 @@ type LogPublisher[C any] struct {
 // Publish will publish all the Observation variables as a log line. It is in
 // the following format:
 // [Experiment Observation] name=%s duration=%s success=%t value=%v error=%v
-func (l *LogPublisher[C]) Publish(o Observation[C]) {
+func (l *LogPublisher[C]) Publish(_ context.Context, o Observation[C]) error {
 	msg := "[Experiment Observation: %s] name=%s duration=%s success=%t value=%v error=%v"
 	args := []interface{}{l.Name, o.Name, o.Duration, o.Success, o.CleanValue, o.Error}
 	if l.Logger == nil {
@@ -33,4 +41,8 @@ func (l *LogPublisher[C]) Publish(o Observation[C]) {
 	} else {
 		l.Logger.Printf(msg, args...)
 	}
+
+	return nil
 }
+
+var _ Publisher[string] = &LogPublisher[string]{}

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,6 +1,7 @@
 package experiment_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jelmersnoeck/experiment"
@@ -10,11 +11,11 @@ func ExampleLogPublisher() {
 	exp := experiment.New[string]().
 		WithPublisher(experiment.NewLogPublisher[string]("publisher", &fmtLogger{}))
 
-	exp.Control(func() (string, error) {
+	exp.Control(func(context.Context) (string, error) {
 		return "Hello world!", nil
 	})
 
-	result, err := exp.Run()
+	result, err := exp.Run(context.Background())
 	if err != nil {
 		panic(err)
 	} else {


### PR DESCRIPTION
This makes experiments context aware, so each candidate can have it's
own specific deadline, as well as an overall deadline if the context
already provides one.

It also pulls the publishing of results into a separate function that is
not run by the publish step, so that publish errors can be handled
separately as well as the publishing timeouts, which must be controlled
by the implementor through a context timeout.
